### PR TITLE
Allow running benchmarks by partial name

### DIFF
--- a/packages/tests/index.js
+++ b/packages/tests/index.js
@@ -61,7 +61,12 @@ function getPackageList() {
       });
     })
     .filter(info => {
-      return !filterPackages || filterPackages.indexOf(info.name) !== -1;
+      return (
+        !filterPackages ||
+        filterPackages.some(
+          filterPackage => info.name.indexOf(filterPackage) > -1
+        )
+      );
     });
 }
 


### PR DESCRIPTION
This allows me to run `npm run benchmark -- styled-components` and run
all the styled-components benchmarks