### PR TITLE
Rename styled-components-v2-plugin to styled-components

### DIFF
--- a/RESULT.md
+++ b/RESULT.md
@@ -12,7 +12,7 @@ Solution | Use CSS | Use Inline-Styles | Mount Time (ms) | Rerender time (ms)
 [aphrodite](https://github.com/Khan/aphrodite) | + | + | 24.31 | 42.14
 [react-css](https://github.com/facebook/react) | + | + | 19.87 | 44.71
 [glam-inline-style](https://github.com/threepointone/glam) | + | + | 19.95 | 48.67
-[styled-components-v2-plugin-inline-styles](https://github.com/styled-components/styled-components/tree/v2) | + | + | 50.36 | 49.16
+[styled-components-inline-styles](https://github.com/styled-components/styled-components/tree/v2) | + | + | 50.36 | 49.16
 [styled-jss-w-o-plugins](https://github.com/cssinjs/styled-jss) | + | - | 66.17 | 49.68
 [rockey-inline](https://github.com/tuchk4/rockey) | + | + | 47.05 | 49.74
 [radium](https://github.com/FormidableLabs/radium) | - | + | 46.74 | 52.18
@@ -20,9 +20,9 @@ Solution | Use CSS | Use Inline-Styles | Mount Time (ms) | Rerender time (ms)
 [styled-jss](https://github.com/cssinjs/styled-jss) | + | - | 87.36 | 55.27
 [styletron](https://github.com/rtsao/styletron) | + | - | 48.35 | 55.3
 [glam-simple](https://github.com/threepointone/glam) | + | - | 25.13 | 57.34
-[styled-components-v2-plugin](https://github.com/styled-components/styled-components/tree/v2) | + | - | 85.46 | 70.32
+[styled-components](https://github.com/styled-components/styled-components/tree/v2) | + | - | 85.46 | 70.32
 [emotion-simple](https://github.com/threepointone/emotion) | + | - | 76.88 | 71.21
-[styled-components-v2-plugin-decouple-cell](https://github.com/styled-components/styled-components/tree/v2) | + | - | 98.35 | 71.59
+[styled-components-decouple-cell](https://github.com/styled-components/styled-components/tree/v2) | + | - | 98.35 | 71.59
 [styled-jsx-dynamic](https://github.com/zeit/styled-jsx) | + | - | 73.92 | 71.95
 [rockey-speedy](https://github.com/tuchk4/rockey) | + | - | 55.2 | 105
 [rockey](https://github.com/tuchk4/rockey) | + | - | 110.16 | 140.09

--- a/packages/benchmarks/styled-components/decouple-cell/package.json
+++ b/packages/benchmarks/styled-components/decouple-cell/package.json
@@ -17,7 +17,7 @@
     "stylis-rule-sheet": "^0.0.6"
   },
   "benchmarks": {
-    "name": "styled-components-v2-plugin-decouple-cell",
+    "name": "styled-components-decouple-cell",
     "link": "https://github.com/styled-components/styled-components/tree/v2",
     "useCSS": true
   }

--- a/packages/benchmarks/styled-components/inline-style/package.json
+++ b/packages/benchmarks/styled-components/inline-style/package.json
@@ -16,7 +16,7 @@
     "styled-components": "^3.1.0-speedy6"
   },
   "benchmarks": {
-    "name": "styled-components-v2-plugin-inline-styles",
+    "name": "styled-components-inline-styles",
     "link": "https://github.com/styled-components/styled-components/tree/v2",
     "useInlineStyles": true,
     "useCSS": true

--- a/packages/benchmarks/styled-components/simple/package.json
+++ b/packages/benchmarks/styled-components/simple/package.json
@@ -16,7 +16,7 @@
     "styled-components": "^3.1.0-speedy6"
   },
   "benchmarks": {
-    "name": "styled-components-v2-plugin",
+    "name": "styled-components",
     "link": "https://github.com/styled-components/styled-components/tree/v2",
     "useCSS": true
   }


### PR DESCRIPTION
Since it's no longer v2 and usage of the plugin is standard nowadays
this cleans the RESULT.md up a bit.