### PR TITLE
Clarify Node version requirement in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ New demos and benchmarks will be soon :)
 
 Here is a little contributing guild:
 
-- Use `node` version `7.9+`
+- Use `node` version `^7.9` (i.e. use `7.9` or newer, but not as new as `8`)
 - Install `lerna` and `yarn` (optional)
 - `lerna bootstrap` or `lerna bootstrap --npm-client=yarn` - install deps in packages
 - `npm i`


### PR DESCRIPTION
Intuitively I understood version `7.9+` to mean 7.9 or newer, including new major versions since Node is generally pretty good at keeping backwards compatibility.

I only learned from #27 that version 7 is actually required, therefore I propose this is made clear in the README. I changed it to use the adequate semantic versioning notation that most people in the ecosystem should be familiar with and added an explanation.